### PR TITLE
Revamp services page layout and styling

### DIFF
--- a/assets/css/responsive.css
+++ b/assets/css/responsive.css
@@ -1928,3 +1928,118 @@
         }
     }
 }
+
+/* ==================== SERVICES PAGE RESPONSIVE ==================== */
+@media (max-width: 1200px) {
+    .services-hero .hero-grid {
+        grid-template-columns: 1fr;
+        gap: 48px;
+    }
+
+    .hero-copy h1 {
+        font-size: 42px;
+    }
+
+    .hero-copy p {
+        max-width: 100%;
+    }
+
+    .cta-card {
+        grid-template-columns: 1fr;
+        text-align: center;
+    }
+
+    .cta-actions {
+        align-items: center;
+    }
+}
+
+@media (max-width: 992px) {
+    .hero-copy h1 {
+        font-size: 38px;
+    }
+
+    .overview-intro h2,
+    .services-grid-section .section-header h2 {
+        font-size: 34px;
+    }
+
+    .services-grid {
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    }
+}
+
+@media (max-width: 768px) {
+    .services-hero {
+        padding: 120px 0 90px;
+    }
+
+    .hero-copy h1 {
+        font-size: 32px;
+    }
+
+    .hero-highlights {
+        gap: 12px;
+    }
+
+    .overview-intro h2 {
+        font-size: 30px;
+    }
+
+    .services-grid-section .section-header h2 {
+        font-size: 32px;
+    }
+
+    .cta-card {
+        padding: 40px 32px;
+    }
+
+    .cta-actions {
+        flex-direction: row;
+        justify-content: center;
+        gap: 12px;
+    }
+}
+
+@media (max-width: 576px) {
+    .hero-copy h1 {
+        font-size: 28px;
+    }
+
+    .hero-copy p,
+    .overview-intro p,
+    .services-grid-section .section-header p,
+    .cta-copy p {
+        font-size: 16px;
+    }
+
+    .hero-actions {
+        flex-direction: column;
+    }
+
+    .overview-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .cta-actions {
+        flex-direction: column;
+    }
+}
+
+@media (max-width: 420px) {
+    .hero-partners {
+        padding: 20px;
+    }
+
+    .metric-card {
+        padding: 28px;
+    }
+
+    .service-card {
+        padding: 28px;
+    }
+
+    .cta-card {
+        padding: 32px 24px;
+    }
+}

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -2365,164 +2365,508 @@ body.dark-theme .why-choose-card {
 }
 
 /* ==================== SERVICES PAGE STYLES ==================== */
-/* Services Introduction */
-.services-intro {
-    text-align: center;
-    padding: 80px 0;
-    background: var(--glass-background-light);
-}
-
-body.dark-theme .services-intro {
-    background: var(--glass-background-dark);
-}
-
-.services-intro h1 {
-    font-size: 42px;
-    margin-bottom: 20px;
-    color: var(--text-light);
+.section-eyebrow {
+    display: inline-block;
+    font-size: 13px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
     font-weight: 600;
+    color: var(--secondary-color);
+    margin-bottom: 18px;
 }
 
-.services-intro p {
-    font-size: 18px;
+body.dark-theme .section-eyebrow {
+    color: var(--primary-color);
+}
+
+.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    border-radius: 999px;
+    padding: 14px 28px;
+    font-weight: 600;
+    text-decoration: none;
+    transition: transform 0.25s ease, box-shadow 0.25s ease, background 0.25s ease, color 0.25s ease;
+    font-size: 16px;
+}
+
+.btn-primary {
+    background: linear-gradient(135deg, var(--primary-color), var(--secondary-color));
+    color: #0a0e17;
+    box-shadow: 0 18px 45px rgba(110, 91, 230, 0.25);
+}
+
+.btn-primary:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 22px 55px rgba(110, 91, 230, 0.32);
+}
+
+.btn-outline {
+    border: 1.5px solid rgba(255, 255, 255, 0.35);
+    color: inherit;
+    background: transparent;
+    backdrop-filter: blur(6px);
+}
+
+body.light-theme .btn-outline {
+    border-color: rgba(13, 18, 30, 0.16);
+}
+
+.btn-outline:hover {
+    transform: translateY(-3px);
+    color: var(--primary-color);
+    border-color: rgba(62, 207, 175, 0.6);
+    box-shadow: 0 18px 40px rgba(62, 207, 175, 0.18);
+}
+
+.services-hero {
+    position: relative;
+    padding: 140px 0 120px;
+    overflow: hidden;
+    background: radial-gradient(circle at top left, rgba(110, 91, 230, 0.2), transparent 55%),
+        radial-gradient(circle at bottom right, rgba(62, 207, 175, 0.18), transparent 50%),
+        linear-gradient(135deg, rgba(12, 18, 32, 0.92), rgba(10, 14, 23, 0.96));
+    color: #f8fafc;
+}
+
+body.light-theme .services-hero {
+    background: radial-gradient(circle at top left, rgba(110, 91, 230, 0.18), transparent 55%),
+        radial-gradient(circle at bottom right, rgba(62, 207, 175, 0.16), transparent 50%),
+        linear-gradient(135deg, #edf2ff, #f8ffff);
     color: var(--text-light);
-    max-width: 800px;
-    margin: 0 auto;
-    line-height: 1.6;
 }
 
-body.dark-theme .services-intro h1,
-body.dark-theme .services-intro p {
-    color: rgba(255, 255, 255, 0.95);
+.services-hero::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(120deg, rgba(255, 255, 255, 0.12), transparent 68%);
+    mix-blend-mode: soft-light;
+    pointer-events: none;
+}
+
+.services-hero .hero-grid {
+    position: relative;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 64px;
+    align-items: center;
+    z-index: 1;
+}
+
+.hero-copy h1 {
+    font-size: 48px;
+    line-height: 1.18;
+    margin-bottom: 22px;
+}
+
+.hero-copy p {
+    font-size: 18px;
+    line-height: 1.7;
+    margin-bottom: 28px;
+    max-width: 560px;
+}
+
+.hero-highlights {
+    list-style: none;
+    margin: 0 0 36px;
+    padding: 0;
+    display: grid;
+    gap: 14px;
+}
+
+.hero-highlights li {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    font-size: 16px;
+}
+
+.hero-highlights i {
+    color: var(--primary-color);
+    background: rgba(62, 207, 175, 0.12);
+    border-radius: 50%;
+    padding: 8px;
+}
+
+.hero-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 18px;
+}
+
+.hero-showcase {
+    display: grid;
+    gap: 24px;
+}
+
+.metric-card {
+    background: rgba(15, 23, 42, 0.55);
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    border-radius: 24px;
+    padding: 32px;
+    backdrop-filter: blur(14px);
+    box-shadow: 0 25px 60px rgba(15, 23, 42, 0.35);
+}
+
+body.light-theme .metric-card {
+    background: rgba(255, 255, 255, 0.85);
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    box-shadow: 0 25px 60px rgba(15, 23, 42, 0.12);
+}
+
+.metric-card .metric-value {
+    font-size: 54px;
+    font-weight: 700;
+    margin-bottom: 16px;
+    display: flex;
+    flex-direction: column;
+    color: var(--primary-color);
+}
+
+.metric-card .metric-value span {
+    font-size: 15px;
+    text-transform: uppercase;
+    letter-spacing: 0.15em;
+    color: rgba(248, 250, 252, 0.72);
+}
+
+body.light-theme .metric-card .metric-value span {
+    color: rgba(15, 23, 42, 0.55);
+}
+
+.metric-card p {
+    margin: 0;
+    line-height: 1.6;
+    color: rgba(226, 232, 240, 0.85);
+}
+
+body.light-theme .metric-card p {
+    color: rgba(15, 23, 42, 0.68);
+}
+
+.hero-partners {
+    background: rgba(255, 255, 255, 0.05);
+    border-radius: 20px;
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    padding: 24px 28px;
+    backdrop-filter: blur(8px);
+}
+
+body.light-theme .hero-partners {
+    background: rgba(255, 255, 255, 0.72);
+    border-color: rgba(148, 163, 184, 0.28);
+}
+
+.hero-partners .partners-label {
+    display: block;
+    font-size: 14px;
+    margin-bottom: 12px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgba(226, 232, 240, 0.8);
+}
+
+body.light-theme .hero-partners .partners-label {
+    color: rgba(15, 23, 42, 0.58);
+}
+
+.partner-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.partner-tags span {
+    display: inline-flex;
+    align-items: center;
+    padding: 8px 14px;
+    border-radius: 999px;
+    font-size: 13px;
+    background: rgba(62, 207, 175, 0.16);
+    color: var(--primary-color);
+    letter-spacing: 0.03em;
+}
+
+.services-overview {
+    padding: 110px 0 70px;
+    background: linear-gradient(180deg, rgba(10, 14, 23, 0.02), transparent 60%);
+}
+
+body.dark-theme .services-overview {
+    background: linear-gradient(180deg, rgba(148, 163, 184, 0.05), transparent 70%);
+}
+
+.overview-intro {
+    text-align: center;
+    max-width: 760px;
+    margin: 0 auto 60px;
+}
+
+.overview-intro h2 {
+    font-size: 38px;
+    margin-bottom: 18px;
+}
+
+.overview-intro p {
+    font-size: 18px;
+    line-height: 1.6;
+    color: rgba(45, 55, 72, 0.78);
+}
+
+body.dark-theme .overview-intro p {
+    color: rgba(226, 232, 240, 0.75);
+}
+
+.overview-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 28px;
+}
+
+.overview-card {
+    background: var(--glass-background-light);
+    border-radius: 20px;
+    padding: 32px 28px;
+    box-shadow: 0 18px 42px rgba(15, 23, 42, 0.12);
+    border: 1px solid rgba(148, 163, 184, 0.18);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+body.dark-theme .overview-card {
+    background: rgba(12, 18, 32, 0.75);
+    border-color: rgba(62, 207, 175, 0.14);
+    box-shadow: 0 20px 50px rgba(8, 14, 26, 0.55);
+}
+
+.overview-card:hover {
+    transform: translateY(-6px);
+    box-shadow: 0 28px 60px rgba(15, 23, 42, 0.18);
+}
+
+.overview-icon {
+    width: 56px;
+    height: 56px;
+    border-radius: 16px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 20px;
+    background: linear-gradient(135deg, rgba(62, 207, 175, 0.2), rgba(110, 91, 230, 0.25));
+    color: var(--secondary-color);
+    font-size: 24px;
+}
+
+.overview-card h3 {
+    margin-bottom: 12px;
+    font-size: 22px;
+}
+
+.overview-card p {
+    margin: 0;
+    line-height: 1.6;
+    color: rgba(45, 55, 72, 0.75);
+}
+
+body.dark-theme .overview-card p {
+    color: rgba(226, 232, 240, 0.7);
 }
 
 .services-grid-section {
-    padding: 100px 0;
-    background: var(--background-light);
+    padding: 120px 0;
+    background: linear-gradient(180deg, rgba(148, 163, 184, 0.08), transparent 60%);
 }
 
 body.dark-theme .services-grid-section {
-    background: var(--background-dark);
+    background: linear-gradient(180deg, rgba(10, 14, 23, 0.9), rgba(10, 14, 23, 0.6));
+}
+
+.services-grid-section .section-header {
+    text-align: center;
+    max-width: 820px;
+    margin: 0 auto 70px;
+}
+
+.services-grid-section .section-header h2 {
+    font-size: 40px;
+    margin-bottom: 20px;
+}
+
+.services-grid-section .section-header p {
+    font-size: 18px;
+    line-height: 1.65;
+    color: rgba(45, 55, 72, 0.75);
+}
+
+body.dark-theme .services-grid-section .section-header p {
+    color: rgba(226, 232, 240, 0.75);
 }
 
 .services-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-    gap: 30px;
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 0 20px;
+    grid-template-columns: repeat(auto-fit, minmax(290px, 1fr));
+    gap: 34px;
 }
 
 .service-card {
-    background: var(--glass-background-light);
-    border-radius: 15px;
-    padding: 35px 25px;
-    text-align: center;
-    transition: all 0.3s ease;
-    border: 2px solid rgba(62, 207, 175, 0.2);
-    box-shadow: 0 8px 32px rgba(62, 207, 175, 0.1);
+    position: relative;
+    background: rgba(255, 255, 255, 0.88);
+    border-radius: 24px;
+    padding: 34px;
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    box-shadow: 0 25px 60px rgba(15, 23, 42, 0.14);
+    display: flex;
+    flex-direction: column;
+    gap: 26px;
+    height: 100%;
+    transition: transform 0.35s ease, box-shadow 0.35s ease, border-color 0.35s ease;
 }
 
 body.dark-theme .service-card {
-    background: var(--glass-background-dark);
-    border: 2px solid rgba(62, 207, 175, 0.15);
-    box-shadow: 0 8px 32px rgba(62, 207, 175, 0.08);
+    background: rgba(12, 18, 32, 0.75);
+    border-color: rgba(62, 207, 175, 0.18);
+    box-shadow: 0 25px 65px rgba(8, 14, 26, 0.6);
 }
 
-.service-card i {
-    font-size: 48px;
-    color: var(--primary-color);
-    margin-bottom: 25px;
-    transition: all 0.3s ease;
-}
-
-.service-card h3 {
-    font-size: 24px;
-    margin-bottom: 15px;
-    color: var(--text-light);
-    font-weight: 600;
-}
-
-.service-card p {
-    font-size: 16px;
-    color: var(--text-light);
-    line-height: 1.6;
-    margin-bottom: 25px;
-}
-
-body.dark-theme .service-card h3 {
-    color: rgba(255, 255, 255, 0.95);
-}
-
-body.dark-theme .service-card p {
-    color: rgba(255, 255, 255, 0.85);
-}
-
-.service-card .learn-more {
-    display: inline-block;
-    padding: 12px 25px;
-    background: var(--primary-color);
-    color: white;
-    text-decoration: none;
-    border-radius: 25px;
-    font-weight: 600;
-    transition: all 0.3s ease;
-    box-shadow: 0 4px 6px rgba(62, 207, 175, 0.2);
-}
-
-.service-card .learn-more:hover {
-    background: var(--secondary-color);
-    transform: translateY(-3px);
-    box-shadow: 0 6px 12px rgba(62, 207, 175, 0.3);
+.service-card::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: linear-gradient(135deg, rgba(62, 207, 175, 0.08), rgba(110, 91, 230, 0.12));
+    opacity: 0;
+    transition: opacity 0.35s ease;
+    pointer-events: none;
 }
 
 .service-card:hover {
-    transform: translateY(-8px);
-    border-color: var(--primary-color);
-    box-shadow: 0 12px 36px rgba(62, 207, 175, 0.2);
+    transform: translateY(-12px);
+    border-color: rgba(62, 207, 175, 0.45);
+    box-shadow: 0 35px 75px rgba(15, 23, 42, 0.2);
 }
 
-body.dark-theme .service-card:hover {
-    border-color: var(--primary-color);
-    box-shadow: 0 12px 36px rgba(62, 207, 175, 0.15);
+.service-card:hover::after {
+    opacity: 1;
 }
 
-.service-card:hover i {
-    transform: scale(1.1);
+.service-card-icon {
+    position: relative;
+    width: 64px;
+    height: 64px;
+    border-radius: 18px;
+    display: grid;
+    place-items: center;
+    background: linear-gradient(135deg, rgba(62, 207, 175, 0.2), rgba(110, 91, 230, 0.24));
     color: var(--secondary-color);
+    font-size: 26px;
+    z-index: 1;
+}
+
+.service-card-body {
+    position: relative;
+    z-index: 1;
+}
+
+.service-card-body h3 {
+    margin-bottom: 14px;
+    font-size: 24px;
+}
+
+.service-card-body p {
+    margin: 0;
+    line-height: 1.65;
+    color: rgba(45, 55, 72, 0.78);
+}
+
+body.dark-theme .service-card-body p {
+    color: rgba(226, 232, 240, 0.78);
+}
+
+.service-card-footer {
+    position: relative;
+    z-index: 1;
+}
+
+.service-card .learn-more {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    font-weight: 600;
+    color: var(--secondary-color);
+    text-decoration: none;
+    font-size: 15px;
+    letter-spacing: 0.01em;
+    transition: gap 0.25s ease, color 0.25s ease;
+}
+
+body.dark-theme .service-card .learn-more {
+    color: var(--primary-color);
+}
+
+.service-card .learn-more::after {
+    content: "\f061";
+    font-family: "Font Awesome 6 Free";
+    font-weight: 900;
+    font-size: 13px;
+    transition: transform 0.25s ease;
+}
+
+.service-card:hover .learn-more {
+    gap: 14px;
+}
+
+.service-card:hover .learn-more::after {
+    transform: translateX(4px);
 }
 
 .cta-section {
-    text-align: center;
-    padding: 100px 0;
-    background: var(--glass-background-light);
+    padding: 120px 0;
+    background: linear-gradient(180deg, transparent, rgba(62, 207, 175, 0.08));
 }
 
 body.dark-theme .cta-section {
-    background: var(--glass-background-dark);
+    background: linear-gradient(180deg, rgba(10, 14, 23, 0.8), rgba(62, 207, 175, 0.15));
 }
 
-.cta-section h2 {
+.cta-card {
+    display: grid;
+    grid-template-columns: minmax(0, 2.2fr) minmax(0, 1fr);
+    align-items: center;
+    gap: 40px;
+    padding: 48px 56px;
+    border-radius: 28px;
+    background: linear-gradient(135deg, rgba(62, 207, 175, 0.25), rgba(110, 91, 230, 0.28));
+    box-shadow: 0 28px 75px rgba(15, 23, 42, 0.22);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+body.light-theme .cta-card {
+    background: linear-gradient(135deg, rgba(62, 207, 175, 0.16), rgba(110, 91, 230, 0.22));
+    border-color: rgba(148, 163, 184, 0.28);
+}
+
+.cta-copy h2 {
     font-size: 36px;
-    margin-bottom: 20px;
-    color: var(--text-light);
-    font-weight: 600;
+    margin-bottom: 16px;
 }
 
-.cta-section p {
+.cta-copy p {
+    margin: 0;
     font-size: 18px;
-    color: var(--text-light);
-    margin-bottom: 40px;
-    line-height: 1.6;
+    line-height: 1.65;
+    color: rgba(226, 232, 240, 0.82);
 }
 
-body.dark-theme .cta-section h2 {
-    color: rgba(255, 255, 255, 0.95);
+body.light-theme .cta-copy p {
+    color: rgba(45, 55, 72, 0.78);
 }
 
-body.dark-theme .cta-section p {
-    color: rgba(255, 255, 255, 0.85);
+.cta-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
 }
 
 /* ==================== PROJECTS PAGE STYLES ==================== */

--- a/services.html
+++ b/services.html
@@ -322,73 +322,173 @@
     </div>
 
     <main class="page-content" id="main-content">
-        <!-- Services Introduction -->
-        <section class="services-intro">
+        <!-- Services Hero -->
+        <section class="services-hero">
+            <div class="container hero-grid">
+                <div class="hero-copy">
+                    <span class="section-eyebrow">What we deliver</span>
+                    <h1>End-to-end digital solutions crafted for ambitious teams.</h1>
+                    <p>From insight-driven strategy to beautifully engineered products, our multidisciplinary experts
+                        partner with you to accelerate growth and create experiences your customers love.</p>
+                    <ul class="hero-highlights">
+                        <li><i class="fas fa-circle-check"></i>Tailored roadmaps aligned to your goals</li>
+                        <li><i class="fas fa-circle-check"></i>Cross-functional specialists on every engagement</li>
+                        <li><i class="fas fa-circle-check"></i>Measurable outcomes and ongoing optimisation</li>
+                    </ul>
+                    <div class="hero-actions">
+                        <a href="contact.html" class="btn btn-primary">Book a consultation</a>
+                        <a href="projects.html" class="btn btn-outline">View success stories</a>
+                    </div>
+                </div>
+                <div class="hero-showcase">
+                    <div class="metric-card">
+                        <div class="metric-value">96%<span>client satisfaction</span></div>
+                        <p>Backed by transparent delivery and proactive support throughout each project lifecycle.</p>
+                    </div>
+                    <div class="hero-partners">
+                        <span class="partners-label">Trusted by innovators in</span>
+                        <div class="partner-tags">
+                            <span>Fintech</span>
+                            <span>Healthtech</span>
+                            <span>eCommerce</span>
+                            <span>Public Sector</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Services Overview -->
+        <section class="services-overview">
             <div class="container">
-                <h1>Our Services</h1>
-                <p>We offer a wide range of digital solutions to help your business grow and succeed in the modern
-                    world.</p>
+                <div class="overview-intro">
+                    <span class="section-eyebrow">How we partner</span>
+                    <h2>Strategy, delivery, and support under one roof.</h2>
+                    <p>We combine deep technical expertise with human-centred design to unlock meaningful change for
+                        organisations at every stage of their digital journey.</p>
+                </div>
+                <div class="overview-grid">
+                    <div class="overview-card">
+                        <div class="overview-icon"><i class="fas fa-compass"></i></div>
+                        <h3>Strategic Discovery</h3>
+                        <p>Rapid workshops, product roadmaps, and technical audits that align every stakeholder on
+                            vision and value.</p>
+                    </div>
+                    <div class="overview-card">
+                        <div class="overview-icon"><i class="fas fa-layer-group"></i></div>
+                        <h3>Integrated Delivery</h3>
+                        <p>Designers, engineers, and analysts collaborating seamlessly to ship resilient, scalable
+                            solutions.</p>
+                    </div>
+                    <div class="overview-card">
+                        <div class="overview-icon"><i class="fas fa-headset"></i></div>
+                        <h3>Continuous Evolution</h3>
+                        <p>Post-launch optimisation, growth experiments, and managed services that keep momentum
+                            strong.</p>
+                    </div>
+                </div>
             </div>
         </section>
 
         <!-- Services Grid Section -->
         <section class="services-grid-section">
             <div class="container">
+                <div class="section-header">
+                    <span class="section-eyebrow">Core capabilities</span>
+                    <h2>Flexible engagements tailored to your business goals.</h2>
+                    <p>Choose the expertise you need or combine services for a fully managed transformation. Every
+                        engagement is supported by clear communication, transparent metrics, and senior leadership
+                        oversight.</p>
+                </div>
                 <div class="services-grid">
                     <!-- Service Card 1: Software & Web Development -->
                     <div class="service-card" data-aos="fade-up">
-                        <i class="fas fa-code"></i>
-                        <h3>Software & Web Development</h3>
-                        <p>We create cutting-edge software and web solutions tailored to your specific business
-                            requirements. From custom web applications to scalable enterprise software, we’ve got you
-                            covered.</p>
-                        <a href="#" class="learn-more">Learn More</a>
+                        <div class="service-card-icon">
+                            <i class="fas fa-code"></i>
+                        </div>
+                        <div class="service-card-body">
+                            <h3>Software & Web Development</h3>
+                            <p>Modern architectures, performance-first engineering, and clean code standards for web and
+                                platform products.</p>
+                        </div>
+                        <div class="service-card-footer">
+                            <a href="#" class="learn-more">Explore build services</a>
+                        </div>
                     </div>
 
                     <!-- Service Card 2: Data Analysis -->
                     <div class="service-card" data-aos="fade-up" data-aos-delay="100">
-                        <i class="fas fa-chart-line"></i>
-                        <h3>Data Analysis</h3>
-                        <p>Transform your raw data into actionable insights that drive informed decision-making. Our
-                            data analysis services help you uncover trends, optimize processes, and make smarter
-                            business decisions.</p>
-                        <a href="#" class="learn-more">Learn More</a>
+                        <div class="service-card-icon">
+                            <i class="fas fa-chart-line"></i>
+                        </div>
+                        <div class="service-card-body">
+                            <h3>Data Analysis</h3>
+                            <p>Pipeline automation, dashboarding, and predictive modelling to surface insights that
+                                inform confident decisions.</p>
+                        </div>
+                        <div class="service-card-footer">
+                            <a href="#" class="learn-more">Discover analytics</a>
+                        </div>
                     </div>
 
                     <!-- Service Card 3: Graphic Design -->
                     <div class="service-card" data-aos="fade-up" data-aos-delay="200">
-                        <i class="fas fa-palette"></i>
-                        <h3>Graphic Design</h3>
-                        <p>Elevate your brand with visually stunning designs that captivate your audience. From logos to
-                            marketing materials, we create designs that leave a lasting impression.</p>
-                        <a href="#" class="learn-more">Learn More</a>
+                        <div class="service-card-icon">
+                            <i class="fas fa-palette"></i>
+                        </div>
+                        <div class="service-card-body">
+                            <h3>Graphic Design</h3>
+                            <p>Brand systems, marketing collateral, and product interfaces built to delight and convert
+                                across every touchpoint.</p>
+                        </div>
+                        <div class="service-card-footer">
+                            <a href="#" class="learn-more">View design craft</a>
+                        </div>
                     </div>
 
                     <!-- Service Card 4: Cybersecurity -->
                     <div class="service-card" data-aos="fade-up" data-aos-delay="300">
-                        <i class="fas fa-shield-alt"></i>
-                        <h3>Cybersecurity</h3>
-                        <p>Protect your digital assets and ensure the integrity of your business operations. Our
-                            cybersecurity services provide robust protection against threats and vulnerabilities.</p>
-                        <a href="#" class="learn-more">Learn More</a>
+                        <div class="service-card-icon">
+                            <i class="fas fa-shield-alt"></i>
+                        </div>
+                        <div class="service-card-body">
+                            <h3>Cybersecurity</h3>
+                            <p>Threat modelling, penetration testing, and compliance support to secure critical systems
+                                and data.</p>
+                        </div>
+                        <div class="service-card-footer">
+                            <a href="#" class="learn-more">Strengthen security</a>
+                        </div>
                     </div>
 
                     <!-- Service Card 5: Cloud Solutions -->
                     <div class="service-card" data-aos="fade-up" data-aos-delay="400">
-                        <i class="fas fa-cloud"></i>
-                        <h3>Cloud Solutions</h3>
-                        <p>Leverage the power of the cloud to enhance scalability, flexibility, and efficiency. We
-                            provide end-to-end cloud solutions tailored to your business needs.</p>
-                        <a href="#" class="learn-more">Learn More</a>
+                        <div class="service-card-icon">
+                            <i class="fas fa-cloud"></i>
+                        </div>
+                        <div class="service-card-body">
+                            <h3>Cloud Solutions</h3>
+                            <p>Migrations, DevOps automation, and managed cloud operations optimised for reliability and
+                                cost efficiency.</p>
+                        </div>
+                        <div class="service-card-footer">
+                            <a href="#" class="learn-more">Scale in the cloud</a>
+                        </div>
                     </div>
 
                     <!-- Service Card 6: Mobile App Development -->
                     <div class="service-card" data-aos="fade-up" data-aos-delay="500">
-                        <i class="fas fa-mobile-alt"></i>
-                        <h3>Mobile App Development</h3>
-                        <p>Reach your audience on the go with custom mobile applications. We develop user-friendly,
-                            high-performance apps for iOS and Android platforms.</p>
-                        <a href="#" class="learn-more">Learn More</a>
+                        <div class="service-card-icon">
+                            <i class="fas fa-mobile-alt"></i>
+                        </div>
+                        <div class="service-card-body">
+                            <h3>Mobile App Development</h3>
+                            <p>Native and cross-platform experiences crafted for usability, performance, and rapid
+                                iteration.</p>
+                        </div>
+                        <div class="service-card-footer">
+                            <a href="#" class="learn-more">Launch your app</a>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -397,9 +497,18 @@
         <!-- Call to Action Section -->
         <section class="cta-section">
             <div class="container">
-                <h2>Ready to Transform Your Business?</h2>
-                <p>Contact us today to discuss your project and learn how we can help you achieve your goals.</p>
-                <a href="contact.html" class="cta-button">Get Started</a>
+                <div class="cta-card">
+                    <div class="cta-copy">
+                        <span class="section-eyebrow">Let’s collaborate</span>
+                        <h2>Ready to shape what’s next for your organisation?</h2>
+                        <p>Share your challenge and we’ll assemble a tailored team to plan the path forward—usually
+                            within two business days.</p>
+                    </div>
+                    <div class="cta-actions">
+                        <a href="contact.html" class="btn btn-primary">Start a project</a>
+                        <a href="open-positions.html" class="btn btn-outline">Meet our experts</a>
+                    </div>
+                </div>
             </div>
         </section>
     </main>


### PR DESCRIPTION
## Summary
- redesign the services hero with a gradient layout, highlight list, and supporting metrics panel
- add an overview section and modernize service cards with icon tiles, refined copy, and updated CTA block
- extend shared styles with reusable button treatments plus responsive rules tailored to the refreshed layout

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68e6b482ac7083248820b1b4486cc022