### PR TITLE
Revamp About page presentation

### DIFF
--- a/about.html
+++ b/about.html
@@ -325,31 +325,73 @@
         <!-- Introduction Section with Hero-style Design -->
         <section class="about-header glassy-section">
             <div class="container">
-                <h1>About Us</h1>
-                <p class="section-description">At Vortixia, we are passionate about delivering innovative digital solutions that empower businesses to
-                    thrive in the modern world. Our team of experts specializes in software development, data analysis, and
-                    graphic design, ensuring that every project we undertake is both impactful and visually stunning.</p>
+                <div class="about-hero">
+                    <div class="about-hero__content">
+                        <span class="about-eyebrow">Inside Vortixia</span>
+                        <h1>About Us</h1>
+                        <p class="section-description">We are a multidisciplinary team of strategists, designers, and engineers building digital products that help ambitious organisations move with confidence. From discovery to delivery, we orchestrate every engagement with craft and care.</p>
+
+                        <div class="about-hero__highlights">
+                            <span class="highlight-chip"><i class="fas fa-star"></i>Human-centred strategy</span>
+                            <span class="highlight-chip"><i class="fas fa-wand-magic-sparkles"></i>Design with intention</span>
+                            <span class="highlight-chip"><i class="fas fa-rocket"></i>Momentum from day one</span>
+                        </div>
+                    </div>
+
+                    <aside class="about-hero__card" aria-label="Vortixia highlights">
+                        <div class="about-hero__card-body">
+                            <h2>Trusted by forward-thinking teams</h2>
+                            <p>Every collaboration is anchored in measurable impact, transparent partnership, and an obsession with exceptional experiences.</p>
+                            <ul class="about-hero__stats">
+                                <li>
+                                    <span class="stat-value">120+</span>
+                                    <span class="stat-label">Digital initiatives launched</span>
+                                </li>
+                                <li>
+                                    <span class="stat-value">40%</span>
+                                    <span class="stat-label">Average efficiency gains for clients</span>
+                                </li>
+                                <li>
+                                    <span class="stat-value">98%</span>
+                                    <span class="stat-label">Client satisfaction score</span>
+                                </li>
+                            </ul>
+                        </div>
+                    </aside>
+                </div>
             </div>
         </section>
 
         <!-- Mission & Vision Section -->
         <section class="about-section glassy-section">
             <div class="container">
+                <div class="section-intro">
+                    <span class="section-eyebrow">Mission &amp; Vision</span>
+                    <h2>Purpose-led partnerships that unlock value</h2>
+                    <p class="section-description">We pair rigorous strategy with inspired execution so every release, campaign, and platform strengthens the connection between our clients and the people they serve.</p>
+                </div>
+
                 <div class="mission-vision">
-                    <div class="mission-box">
-                        <i class="fas fa-bullseye mission-icon"></i>
-                        <h2>Our Mission</h2>
-                        <p>Our mission is to transform ideas into powerful digital experiences. We believe in the power of
-                            technology to drive growth, and we are committed to helping our clients achieve their goals
-                            through cutting-edge solutions.</p>
-                    </div>
-                    <div class="vision-box">
-                        <i class="fas fa-eye vision-icon"></i>
-                        <h2>Our Vision</h2>
-                        <p>We envision a world where businesses of all sizes can leverage technology to innovate, grow, and
-                            connect with their audiences in meaningful ways. By combining creativity, technical expertise,
-                            and data-driven insights, we aim to be the catalyst for digital transformation.</p>
-                    </div>
+                    <article class="mission-box insight-card">
+                        <div class="insight-icon" aria-hidden="true"><i class="fas fa-bullseye"></i></div>
+                        <h3>Our Mission</h3>
+                        <p>To transform ideas into powerful digital experiences that accelerate growth. We champion experimentation, iterate with purpose, and deliver solutions that make a measurable difference.</p>
+                        <ul class="insight-list">
+                            <li>Collaborative discovery and co-creation</li>
+                            <li>Inclusive design and accessible build standards</li>
+                            <li>Performance-focused delivery frameworks</li>
+                        </ul>
+                    </article>
+                    <article class="vision-box insight-card">
+                        <div class="insight-icon" aria-hidden="true"><i class="fas fa-eye"></i></div>
+                        <h3>Our Vision</h3>
+                        <p>To empower every organisation we partner with to innovate boldly and connect meaningfully. We see technology as the bridge that brings ideas to life and people closer together.</p>
+                        <ul class="insight-list">
+                            <li>Future-ready platforms that scale gracefully</li>
+                            <li>Data-rich insights that inform confident decisions</li>
+                            <li>Long-term stewardship beyond launch</li>
+                        </ul>
+                    </article>
                 </div>
             </div>
         </section>
@@ -357,30 +399,32 @@
         <!-- Values Section -->
         <section class="about-section glassy-section">
             <div class="container">
-                <h2>Our Values</h2>
-                <p class="section-description">The principles that guide everything we do</p>
+                <div class="section-intro">
+                    <span class="section-eyebrow">Our Values</span>
+                    <h2>The principles that anchor every engagement</h2>
+                    <p class="section-description">We build teams, processes, and experiences that reflect a shared commitment to craft, integrity, and continuous improvement.</p>
+                </div>
                 <div class="values-grid">
-                    <div class="value-card">
-                        <i class="fas fa-lightbulb"></i>
-                        <h3>Innovation</h3>
-                        <p>We constantly push the boundaries of what's possible, embracing new technologies and creative
-                            approaches.</p>
-                    </div>
-                    <div class="value-card">
-                        <i class="fas fa-shield-alt"></i>
-                        <h3>Integrity</h3>
-                        <p>We believe in transparency, honesty, and building trust with our clients and partners.</p>
-                    </div>
-                    <div class="value-card">
-                        <i class="fas fa-users"></i>
-                        <h3>Collaboration</h3>
-                        <p>We work closely with our clients to understand their needs and deliver tailored solutions.</p>
-                    </div>
-                    <div class="value-card">
-                        <i class="fas fa-award"></i>
-                        <h3>Excellence</h3>
-                        <p>We strive for excellence in everything we do, ensuring the highest quality in our work.</p>
-                    </div>
+                    <article class="value-card">
+                        <div class="value-card__icon" aria-hidden="true"><i class="fas fa-lightbulb"></i></div>
+                        <h3>Innovation with intention</h3>
+                        <p>We constantly push the boundaries of what is possible, pairing emerging technology with grounded strategy to unlock smarter ways of working.</p>
+                    </article>
+                    <article class="value-card">
+                        <div class="value-card__icon" aria-hidden="true"><i class="fas fa-shield-alt"></i></div>
+                        <h3>Integrity at every touchpoint</h3>
+                        <p>Transparency, honesty, and accountability shape every interaction. We build trust by delivering on promises and communicating proactively.</p>
+                    </article>
+                    <article class="value-card">
+                        <div class="value-card__icon" aria-hidden="true"><i class="fas fa-users"></i></div>
+                        <h3>Collaboration without silos</h3>
+                        <p>We create multidisciplinary teams that embed with our clients, aligning around shared objectives and co-owning the path to success.</p>
+                    </article>
+                    <article class="value-card">
+                        <div class="value-card__icon" aria-hidden="true"><i class="fas fa-award"></i></div>
+                        <h3>Excellence, measured</h3>
+                        <p>From code quality to customer sentiment, we elevate every deliverable with clear success metrics and ongoing optimisation.</p>
+                    </article>
                 </div>
             </div>
         </section>
@@ -388,12 +432,44 @@
         <!-- Journey Section with Timeline -->
         <section class="about-section glassy-section">
             <div class="container">
-                <h2>Our Journey</h2>
-                <p class="section-description">From humble beginnings to trusted digital partner</p>
-                <div class="journey-content">
-                    <p>Founded in 2020, Vortixia started as a small team of tech enthusiasts with a shared passion for
-                        innovation. Over the years, we've grown into a trusted partner for businesses across various
-                        industries, helping them navigate the digital landscape and achieve their goals.</p>
+                <div class="section-intro">
+                    <span class="section-eyebrow">Our Journey</span>
+                    <h2>From early experiments to enterprise-ready solutions</h2>
+                    <p class="section-description">We grew alongside our clients, evolving our craft while staying grounded in the values that sparked Vortixia in the first place.</p>
+                </div>
+                <div class="journey-timeline" aria-label="Company timeline">
+                    <div class="timeline-item">
+                        <div class="timeline-marker" aria-hidden="true"></div>
+                        <div class="timeline-content">
+                            <span class="timeline-year">2020</span>
+                            <h3>Vortixia is founded</h3>
+                            <p>Three specialists unite around a shared belief that design and engineering should be equally strategic. Our first product release earns regional recognition.</p>
+                        </div>
+                    </div>
+                    <div class="timeline-item">
+                        <div class="timeline-marker" aria-hidden="true"></div>
+                        <div class="timeline-content">
+                            <span class="timeline-year">2021</span>
+                            <h3>Growing our delivery capability</h3>
+                            <p>We launch dedicated data and cybersecurity practices, allowing us to support clients through complex transformations across their digital ecosystem.</p>
+                        </div>
+                    </div>
+                    <div class="timeline-item">
+                        <div class="timeline-marker" aria-hidden="true"></div>
+                        <div class="timeline-content">
+                            <span class="timeline-year">2023</span>
+                            <h3>Global partnerships and scale</h3>
+                            <p>With projects across five countries, we formalise strategic partnerships and introduce our proprietary performance framework to drive measurable outcomes.</p>
+                        </div>
+                    </div>
+                    <div class="timeline-item">
+                        <div class="timeline-marker" aria-hidden="true"></div>
+                        <div class="timeline-content">
+                            <span class="timeline-year">Today</span>
+                            <h3>Building what's next</h3>
+                            <p>We continue to invest in research, emerging tech, and people-first design so our clients can launch with clarity and adapt with ease.</p>
+                        </div>
+                    </div>
                 </div>
             </div>
         </section>
@@ -401,32 +477,32 @@
         <!-- Why Choose Us Section -->
         <section class="about-section glassy-section">
             <div class="container">
-                <h2>Why Choose Vortixia?</h2>
-                <p class="section-description">What sets us apart from the competition</p>
+                <div class="section-intro">
+                    <span class="section-eyebrow">Why Vortixia</span>
+                    <h2>What partnering with us feels like</h2>
+                    <p class="section-description">We bring clarity to complexity, tailoring every engagement to the realities of your organisation and the ambitions of your teams.</p>
+                </div>
                 <div class="why-choose-grid">
-                    <div class="why-choose-card">
-                        <i class="fas fa-thumbs-up"></i>
-                        <h3>Tailored Solutions</h3>
-                        <p>We don't believe in one-size-fits-all. Every solution we create is customized to meet your unique
-                            needs.</p>
-                    </div>
-                    <div class="why-choose-card">
-                        <i class="fas fa-chart-line"></i>
-                        <h3>Data-Driven Approach</h3>
-                        <p>We use data to inform every decision, ensuring that our solutions deliver measurable results.</p>
-                    </div>
-                    <div class="why-choose-card">
-                        <i class="fas fa-hands-helping"></i>
-                        <h3>End-to-End Support</h3>
-                        <p>From concept to execution, we're with you every step of the way, providing ongoing support and
-                            maintenance.</p>
-                    </div>
-                    <div class="why-choose-card">
-                        <i class="fas fa-trophy"></i>
-                        <h3>Proven Track Record</h3>
-                        <p>Our portfolio of successful projects speaks for itself. We've helped businesses achieve their
-                            goals time and time again.</p>
-                    </div>
+                    <article class="why-choose-card">
+                        <div class="why-card__icon" aria-hidden="true"><i class="fas fa-thumbs-up"></i></div>
+                        <h3>Tailored, end-to-end solutions</h3>
+                        <p>From strategy and design to deployment and training, we build programmes that flex with evolving priorities and scale alongside your business.</p>
+                    </article>
+                    <article class="why-choose-card">
+                        <div class="why-card__icon" aria-hidden="true"><i class="fas fa-chart-line"></i></div>
+                        <h3>Data-infused decision making</h3>
+                        <p>We surface actionable insights at every milestone so you can validate investments, iterate with confidence, and prove value quickly.</p>
+                    </article>
+                    <article class="why-choose-card">
+                        <div class="why-card__icon" aria-hidden="true"><i class="fas fa-hands-helping"></i></div>
+                        <h3>Embedded partnership</h3>
+                        <p>Our team works as an extension of yours, offering proactive communication, transparent roadmaps, and ongoing optimisation after launch.</p>
+                    </article>
+                    <article class="why-choose-card">
+                        <div class="why-card__icon" aria-hidden="true"><i class="fas fa-trophy"></i></div>
+                        <h3>Proven results, shared wins</h3>
+                        <p>Whether it's increased revenue or improved retention, we celebrate success alongside you and document learnings for the next initiative.</p>
+                    </article>
                 </div>
             </div>
         </section>
@@ -434,9 +510,14 @@
         <!-- Call to Action Section -->
         <section class="about-cta glassy-section">
             <div class="container">
-                <h2>Ready to Transform Your Business?</h2>
-                <p>Let's work together to create something amazing</p>
-                <a href="contact.html" class="cta-button">Get In Touch</a>
+                <div class="cta-content">
+                    <div class="cta-copy">
+                        <span class="section-eyebrow">Let's build what's next</span>
+                        <h2>Ready to transform your digital future?</h2>
+                        <p>Tell us about your goals and we'll assemble the right team to deliver momentum. Workshops, roadmaps, and prototypes are just the beginning.</p>
+                    </div>
+                    <a href="contact.html" class="cta-button">Start a conversation</a>
+                </div>
             </div>
         </section>
     </main>

--- a/assets/css/responsive.css
+++ b/assets/css/responsive.css
@@ -450,74 +450,117 @@
 /* Large screens (desktops) */
 @media screen and (min-width: 1200px) {
     .about-header {
-        padding: 150px 0 80px;
-    }
-
-    .about-header h1 {
-        font-size: 48px;
+        padding: 190px 0 150px;
     }
 
     .mission-vision {
-        gap: 60px;
+        gap: 48px;
     }
 }
 
 /* Medium screens (tablets and small desktops) */
 @media screen and (max-width: 1199px) and (min-width: 768px) {
     .about-header {
-        padding: 120px 0 60px;
+        padding: 150px 0 120px;
     }
 
-    .about-header h1 {
-        font-size: 40px;
+    .about-hero {
+        grid-template-columns: 1fr;
+    }
+
+    .about-hero__card {
+        max-width: 540px;
+        margin: 0 auto;
     }
 
     .mission-vision {
-        gap: 40px;
+        gap: 32px;
     }
 
     .values-grid {
         grid-template-columns: repeat(2, 1fr);
+    }
+
+    .cta-content {
+        flex-direction: column;
+        text-align: center;
+    }
+
+    .about-cta .cta-button {
+        align-self: center;
     }
 }
 
 /* Small screens (mobile devices) */
 @media screen and (max-width: 767px) {
     .about-header {
-        padding: 100px 0 40px;
+        padding: 120px 0 100px;
     }
 
-    .about-header h1 {
-        font-size: 32px;
-    }
-
-    .about-header p {
-        font-size: 16px;
-    }
-
-    .mission-vision {
+    .about-hero {
         grid-template-columns: 1fr;
-        gap: 30px;
+        gap: 40px;
+    }
+
+    .about-hero__content h1 {
+        font-size: 2.4rem;
+    }
+
+    .about-hero__highlights {
+        gap: 8px;
+    }
+
+    .highlight-chip {
+        width: 100%;
+        justify-content: center;
+    }
+
+    .about-hero__card {
+        margin: 0 auto;
+    }
+
+    .section-intro {
+        margin-bottom: 40px;
     }
 
     .values-grid {
         grid-template-columns: 1fr;
     }
 
-    .team-grid {
+    .journey-timeline {
+        padding-left: 16px;
+    }
+
+    .journey-timeline::before {
+        left: 8px;
+    }
+
+    .timeline-item {
+        grid-template-columns: 1fr;
+        padding-left: 16px;
+    }
+
+    .timeline-marker {
+        margin-left: -24px;
+    }
+
+    .cta-content {
+        flex-direction: column;
+        padding: 32px 28px;
+        text-align: center;
+    }
+
+    .cta-copy h2 {
+        font-size: 1.9rem;
+    }
+
+    .why-choose-grid {
         grid-template-columns: 1fr;
     }
 
-    .about-section h2 {
-        font-size: 28px;
-    }
-
-    .about-section h3 {
-        font-size: 22px;
-    }
-
-    .about-section p {
-        font-size: 16px;
+    .about-cta .cta-button {
+        width: 100%;
+        justify-content: center;
     }
 }
 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -2060,162 +2060,346 @@ header {
 
 /* About Header Section */
 .about-header {
-    padding: 150px 0 80px;
-    text-align: center;
+    padding: 170px 0 130px;
     position: relative;
+    overflow: hidden;
 }
 
-.about-header h1 {
-    font-size: 48px;
-    margin-bottom: 25px;
-    color: var(--text-light);
+.about-header::before,
+.about-header::after {
+    content: "";
+    position: absolute;
+    border-radius: 50%;
+    filter: blur(0px);
+    opacity: 0.5;
+    pointer-events: none;
 }
 
-body.dark-theme .about-header h1 {
-    color: var(--text-dark);
+.about-header::before {
+    width: 520px;
+    height: 520px;
+    right: -140px;
+    top: -220px;
+    background: radial-gradient(circle at center, rgba(62, 207, 175, 0.35), rgba(62, 207, 175, 0));
 }
 
-.about-header p.section-description {
-    font-size: 18px;
+.about-header::after {
+    width: 420px;
+    height: 420px;
+    left: -180px;
+    bottom: -160px;
+    background: radial-gradient(circle at center, rgba(110, 91, 230, 0.35), rgba(110, 91, 230, 0));
+}
+
+.about-hero {
+    display: grid;
+    grid-template-columns: minmax(0, 1.2fr) minmax(280px, 0.8fr);
+    gap: 60px;
+    align-items: center;
+    position: relative;
+    z-index: 1;
+}
+
+.about-hero__content h1 {
+    font-size: 3.25rem;
+    margin-bottom: 18px;
+}
+
+.about-eyebrow,
+.section-eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 0.85rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    font-weight: 600;
+    color: var(--primary-color);
+    margin-bottom: 18px;
+}
+
+.about-eyebrow::before,
+.section-eyebrow::before {
+    content: "";
+    display: inline-block;
+    width: 34px;
+    height: 2px;
+    background: currentColor;
+    border-radius: 999px;
+}
+
+.about-header .section-description {
+    max-width: 680px;
     line-height: 1.8;
-    max-width: 900px;
-    margin: 0 auto;
-    color: var(--text-light);
+    margin-bottom: 32px;
 }
 
-body.dark-theme .about-header p.section-description {
-    color: var(--text-dark);
+.about-hero__highlights {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.highlight-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 18px;
+    border-radius: 999px;
+    background: rgba(62, 207, 175, 0.12);
+    color: inherit;
+    font-weight: 500;
+    backdrop-filter: blur(12px);
+    border: 1px solid rgba(62, 207, 175, 0.2);
+}
+
+body.dark-theme .highlight-chip {
+    background: rgba(62, 207, 175, 0.18);
+    border-color: rgba(62, 207, 175, 0.24);
+}
+
+.highlight-chip i {
+    color: var(--primary-color);
+    font-size: 0.95rem;
+}
+
+.about-hero__card {
+    position: relative;
+    border-radius: 26px;
+    overflow: hidden;
+    background: linear-gradient(180deg, rgba(62, 207, 175, 0.14), rgba(110, 91, 230, 0.24));
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    box-shadow: 0 18px 40px rgba(10, 14, 23, 0.25);
+}
+
+body.light-theme .about-hero__card {
+    background: linear-gradient(180deg, rgba(62, 207, 175, 0.12), rgba(99, 179, 237, 0.18));
+    border-color: rgba(15, 23, 42, 0.08);
+    box-shadow: 0 24px 45px rgba(15, 23, 42, 0.1);
+}
+
+.about-hero__card::after {
+    content: "";
+    position: absolute;
+    inset: 12px;
+    border-radius: 22px;
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    opacity: 0.65;
+    pointer-events: none;
+}
+
+.about-hero__card-body {
+    position: relative;
+    padding: 50px 44px;
+    display: flex;
+    flex-direction: column;
+    gap: 26px;
+}
+
+.about-hero__card h2 {
+    font-size: 1.75rem;
+    margin: 0;
+}
+
+.about-hero__card p {
+    margin: 0;
+    line-height: 1.7;
+}
+
+.about-hero__stats {
+    list-style: none;
+    display: grid;
+    gap: 22px;
+    margin: 0;
+    padding: 0;
+}
+
+.about-hero__stats li {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.stat-value {
+    font-size: 2.1rem;
+    font-weight: 700;
+    color: var(--primary-color);
+}
+
+.stat-label {
+    font-size: 0.95rem;
+    line-height: 1.4;
+    opacity: 0.8;
 }
 
 /* About Sections Common Styles */
 .about-section {
-    padding: 80px 0;
+    padding: 110px 0;
+}
+
+.section-intro {
     text-align: center;
+    max-width: 780px;
+    margin: 0 auto 60px;
 }
 
-.about-section:last-child {
-    border-bottom: none;
-}
-
-.about-section h2 {
-    font-size: 36px;
-    margin-bottom: 40px;
-    color: var(--text-light);
-}
-
-.about-section h3 {
-    font-size: 24px;
+.section-intro h2 {
+    font-size: 2.4rem;
     margin-bottom: 20px;
-    color: var(--text-light);
 }
 
-.about-section p {
-    font-size: 18px;
-    line-height: 1.6;
-    color: var(--text-light);
-    max-width: 800px;
-    margin: 0 auto 30px;
+.section-intro .section-description {
+    margin: 0;
+    line-height: 1.8;
 }
 
 /* Mission & Vision Grid */
 .mission-vision {
     display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 40px;
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 0 20px;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 36px;
 }
 
-.mission-box,
-.vision-box {
-    background: var(--glass-background-light);
-    padding: 40px;
-    border-radius: 15px;
-    border: 2px solid rgba(62, 207, 175, 0.2);
-    box-shadow: 0 8px 32px rgba(62, 207, 175, 0.1);
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
-    text-align: center;
+.insight-card {
+    position: relative;
+    padding: 44px 36px;
+    border-radius: 24px;
+    background: rgba(15, 23, 42, 0.55);
+    border: 1px solid rgba(62, 207, 175, 0.22);
+    box-shadow: 0 18px 42px rgba(8, 11, 20, 0.35);
+    backdrop-filter: blur(16px);
+    transition: transform var(--animation-duration-medium) var(--animation-ease),
+        box-shadow var(--animation-duration-medium) var(--animation-ease);
 }
 
-body.dark-theme .mission-box,
-body.dark-theme .vision-box {
-    background: var(--background-dark);
-    border: 2px solid rgba(62, 207, 175, 0.15);
-    box-shadow: 0 8px 32px rgba(62, 207, 175, 0.08);
+body.light-theme .insight-card {
+    background: rgba(255, 255, 255, 0.88);
+    border-color: rgba(62, 207, 175, 0.16);
+    box-shadow: 0 18px 38px rgba(15, 23, 42, 0.12);
 }
 
-.mission-box:hover,
-.vision-box:hover {
-    transform: translateY(-5px);
-    border-color: var(--primary-color);
-    box-shadow: 0 12px 36px rgba(62, 207, 175, 0.2);
+.insight-card:hover {
+    transform: translateY(-8px);
+    box-shadow: 0 26px 52px rgba(0, 0, 0, 0.2);
 }
 
-body.dark-theme .mission-box:hover,
-body.dark-theme .vision-box:hover {
-    border-color: var(--primary-color);
-    box-shadow: 0 12px 36px rgba(62, 207, 175, 0.15);
-}
-
-.mission-icon,
-.vision-icon {
-    font-size: 36px;
+.insight-icon {
+    width: 54px;
+    height: 54px;
+    border-radius: 16px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(62, 207, 175, 0.2);
     color: var(--primary-color);
-    margin-bottom: 20px;
-    display: block;
+    margin-bottom: 26px;
+    font-size: 1.4rem;
 }
 
-.mission-vision h2 {
-    font-size: 28px;
-    margin-bottom: 20px;
-    margin-top: 0;
+body.light-theme .insight-icon {
+    background: rgba(62, 207, 175, 0.18);
+}
+
+.insight-card h3 {
+    font-size: 1.75rem;
+    margin-bottom: 16px;
+}
+
+.insight-card p {
+    line-height: 1.7;
+    margin-bottom: 26px;
+}
+
+.insight-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 12px;
+}
+
+.insight-list li {
+    position: relative;
+    padding-left: 26px;
+    font-weight: 500;
+}
+
+.insight-list li::before {
+    content: "";
+    position: absolute;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: var(--primary-color);
+    left: 0;
+    top: 8px;
 }
 
 /* Values Grid */
 .values-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    gap: 30px;
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 0 20px;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 28px;
 }
 
 .value-card {
-    background: var(--glass-background-light);
-    padding: 30px;
-    border-radius: 15px;
-    border: 2px solid rgba(62, 207, 175, 0.2);
-    box-shadow: 0 8px 32px rgba(62, 207, 175, 0.1);
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    position: relative;
+    padding: 38px 32px;
+    border-radius: 22px;
+    background: rgba(15, 23, 42, 0.55);
+    border: 1px solid rgba(99, 179, 237, 0.2);
+    backdrop-filter: blur(14px);
+    transition: transform var(--animation-duration-medium) var(--animation-ease),
+        border-color var(--animation-duration-medium) var(--animation-ease);
 }
 
-body.dark-theme .value-card {
-    border: 2px solid rgba(62, 207, 175, 0.15);
-    box-shadow: 0 8px 32px rgba(62, 207, 175, 0.08);
+body.light-theme .value-card {
+    background: rgba(255, 255, 255, 0.9);
+    border-color: rgba(99, 179, 237, 0.16);
+    box-shadow: 0 12px 32px rgba(15, 23, 42, 0.1);
+}
+
+.value-card::after {
+    content: "";
+    position: absolute;
+    inset: 16px;
+    border-radius: 18px;
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    opacity: 0.6;
+    pointer-events: none;
 }
 
 .value-card:hover {
-    transform: translateY(-5px);
-    border-color: var(--primary-color);
-    box-shadow: 0 12px 36px rgba(62, 207, 175, 0.2);
+    transform: translateY(-6px);
+    border-color: rgba(62, 207, 175, 0.45);
 }
 
-body.dark-theme .value-card:hover {
-    border-color: var(--primary-color);
-    box-shadow: 0 12px 36px rgba(62, 207, 175, 0.15);
-}
-
-.value-card i {
-    font-size: 36px;
+.value-card__icon {
+    width: 52px;
+    height: 52px;
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    background: rgba(62, 207, 175, 0.22);
     color: var(--primary-color);
-    margin-bottom: 20px;
+    font-size: 1.3rem;
+    margin-bottom: 24px;
+    position: relative;
+    z-index: 1;
 }
 
 .value-card h3 {
-    font-size: 24px;
-    margin-bottom: 15px;
+    font-size: 1.35rem;
+    margin-bottom: 16px;
+    position: relative;
+    z-index: 1;
+}
+
+.value-card p {
+    margin: 0;
+    line-height: 1.7;
+    position: relative;
+    z-index: 1;
 }
 
 /* Team Grid */
@@ -2269,71 +2453,208 @@ body.dark-theme .value-card:hover {
 }
 
 /* Journey Section */
-.journey-content {
-    max-width: 900px;
+.journey-timeline {
+    position: relative;
+    max-width: 860px;
     margin: 0 auto;
-    padding: 0 20px;
+    padding-left: 28px;
 }
 
-.journey-content p {
-    font-size: 18px;
-    line-height: 1.8;
+.journey-timeline::before {
+    content: "";
+    position: absolute;
+    left: 16px;
+    top: 0;
+    bottom: 0;
+    width: 2px;
+    background: linear-gradient(180deg, rgba(62, 207, 175, 0.6), rgba(110, 91, 230, 0.3));
+}
+
+.timeline-item {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 24px;
+    position: relative;
+    padding-bottom: 36px;
+}
+
+.timeline-item:last-child {
+    padding-bottom: 0;
+}
+
+.timeline-marker {
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: var(--background-dark);
+    border: 3px solid var(--primary-color);
+    box-shadow: 0 0 0 6px rgba(62, 207, 175, 0.18);
+    margin-top: 6px;
+}
+
+body.light-theme .timeline-marker {
+    background: #ffffff;
+}
+
+.timeline-content {
+    padding: 22px 26px;
+    border-radius: 18px;
+    background: rgba(15, 23, 42, 0.55);
+    border: 1px solid rgba(99, 179, 237, 0.18);
+    box-shadow: 0 12px 28px rgba(8, 11, 20, 0.25);
+    backdrop-filter: blur(12px);
+}
+
+body.light-theme .timeline-content {
+    background: rgba(255, 255, 255, 0.92);
+    border-color: rgba(99, 179, 237, 0.14);
+    box-shadow: 0 14px 30px rgba(15, 23, 42, 0.12);
+}
+
+.timeline-year {
+    font-size: 0.9rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--primary-color);
+}
+
+.timeline-content h3 {
+    margin: 12px 0 10px;
+    font-size: 1.45rem;
+}
+
+.timeline-content p {
+    margin: 0;
+    line-height: 1.7;
 }
 
 /* About CTA Section */
 .about-cta {
-    text-align: center;
-    padding: 80px 0;
+    position: relative;
+    overflow: hidden;
+    padding: 110px 0;
 }
 
-.about-cta h2 {
-    font-size: 36px;
-    margin-bottom: 20px;
-    color: var(--text-light);
+.about-cta::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(62, 207, 175, 0.28), rgba(110, 91, 230, 0.35));
+    opacity: 0.9;
 }
 
-.about-cta p {
-    font-size: 18px;
-    color: var(--text-light);
-    margin-bottom: 30px;
+body.light-theme .about-cta::before {
+    background: linear-gradient(135deg, rgba(62, 207, 175, 0.2), rgba(99, 179, 237, 0.25));
 }
 
-body.dark-theme .about-cta h2,
-body.dark-theme .about-cta p {
-    color: var(--text-dark);
+.about-cta .container {
+    position: relative;
+    z-index: 1;
+}
+
+.cta-content {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 40px;
+    padding: 48px 56px;
+    border-radius: 28px;
+    background: rgba(10, 14, 23, 0.65);
+    border: 1px solid rgba(255, 255, 255, 0.22);
+    box-shadow: 0 24px 48px rgba(6, 11, 21, 0.35);
+}
+
+body.light-theme .cta-content {
+    background: rgba(255, 255, 255, 0.92);
+    border-color: rgba(15, 23, 42, 0.08);
+    box-shadow: 0 24px 46px rgba(15, 23, 42, 0.12);
+}
+
+.cta-copy {
+    max-width: 600px;
+}
+
+.cta-copy h2 {
+    font-size: 2.2rem;
+    margin: 14px 0 18px;
+}
+
+.cta-copy p {
+    margin: 0;
+    line-height: 1.8;
+}
+
+.about-cta .cta-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    align-self: flex-start;
+    padding: 18px 36px;
+    font-size: 1rem;
+    border-radius: 999px;
+    background: var(--primary-color);
+    color: #0a0e17;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    box-shadow: 0 16px 30px rgba(62, 207, 175, 0.35);
+}
+
+.about-cta .cta-button:hover {
+    transform: translateY(-4px);
 }
 
 /* Why Choose Us Grid */
 .why-choose-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    gap: 30px;
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 0 20px;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 28px;
 }
 
 .why-choose-card {
-    background: var(--glass-background-light);
-    padding: 30px;
-    border-radius: 15px;
-    border: 2px solid rgba(62, 207, 175, 0.2);
-    box-shadow: 0 8px 32px rgba(62, 207, 175, 0.1);
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    position: relative;
+    padding: 40px 32px;
+    border-radius: 22px;
+    background: rgba(15, 23, 42, 0.55);
+    border: 1px solid rgba(62, 207, 175, 0.2);
+    backdrop-filter: blur(12px);
+    transition: transform var(--animation-duration-medium) var(--animation-ease),
+        border-color var(--animation-duration-medium) var(--animation-ease);
+}
+
+body.light-theme .why-choose-card {
+    background: rgba(255, 255, 255, 0.92);
+    border-color: rgba(62, 207, 175, 0.16);
+    box-shadow: 0 16px 38px rgba(15, 23, 42, 0.1);
 }
 
 .why-choose-card:hover {
-    transform: translateY(-5px);
-    border-color: var(--primary-color);
-    box-shadow: 0 12px 36px rgba(62, 207, 175, 0.2);
+    transform: translateY(-8px);
+    border-color: rgba(62, 207, 175, 0.4);
 }
 
-body.dark-theme .why-choose-card:hover {
-    border-color: var(--primary-color);
-    box-shadow: 0 12px 36px rgba(62, 207, 175, 0.15);
+.why-card__icon {
+    width: 54px;
+    height: 54px;
+    border-radius: 16px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(62, 207, 175, 0.2);
+    color: var(--primary-color);
+    font-size: 1.4rem;
+    margin-bottom: 22px;
 }
 
-.why-choose-card i {
+.why-choose-card h3 {
+    font-size: 1.35rem;
+    margin-bottom: 16px;
+}
+
+.why-choose-card p {
+    margin: 0;
+    line-height: 1.7;
+}
     font-size: 32px;
     color: var(--primary-color);
     margin-bottom: 20px;


### PR DESCRIPTION
## Summary
- redesign the About page hero with a highlight card, badges, and refreshed copy
- expand the mission, values, journey, and reasons-to-choose sections with structured content blocks and timeline storytelling
- add supporting styling and responsive rules for the new layout and CTA treatment

## Testing
- Manually viewed `about.html` via `python -m http.server 8000`


------
https://chatgpt.com/codex/tasks/task_e_68e6bb7f6dc48324a62e2042c63216be